### PR TITLE
Remove use of bash 4 associative arrays from eclasses

### DIFF
--- a/eclass/dlang-compilers.eclass
+++ b/eclass/dlang-compilers.eclass
@@ -11,34 +11,76 @@ ___ECLASS_ONCE_DLANG_COMPILERS="recur -_+^+_- spank"
 EXPORT_FUNCTIONS declare_versions
 
 dlang-compilers_declare_versions() {
-	declare -gA __dlang_dmd_frontend_mapping
-	declare -gA __dlang_gdc_frontend_mapping
-	declare -gA __dlang_ldc2_frontend_mapping
+	declare -ga __dlang_dmd_frontend_archmap
+	declare -ga __dlang_dmd_frontend_versionmap
+	declare -ga __dlang_gdc_frontend_archmap
+	declare -ga __dlang_gdc_frontend_versionmap
+	declare -ga __dlang_ldc2_frontend_archmap
+	declare -ga __dlang_ldc2_frontend_versionmap
 
 	# DMD
-	__dlang_dmd_frontend_mapping=(
-		["2.063"]="2.063 x86 amd64"
-		["2.064"]="2.064 x86 amd64"
-		["2.065"]="2.065 x86 amd64"
-		["2.066"]="2.066 x86 amd64"
-		["2.067"]="2.067"
+	__dlang_dmd_frontend_archmap=(
+		[1]="2.063 x86 amd64"
+		[2]="2.064 x86 amd64"
+		[3]="2.065 x86 amd64"
+		[4]="2.066 x86 amd64"
+		[5]="2.067"
+	)
+	__dlang_dmd_frontend_versionmap=(
+		[1]="2.063"
+		[2]="2.064"
+		[3]="2.065"
+		[4]="2.066"
+		[5]="2.067"
 	)
 
 	# GDC
-	__dlang_gdc_frontend_mapping=(
-		["4.8.1"]="2.063"
-		["4.8.2"]="2.064"
-		["4.8.3"]="2.065 x86 amd64"
-		["4.8.4"]="2.066 x86 amd64"
+	__dlang_gdc_frontend_archmap=(
+		[1]="2.063"
+		[2]="2.064"
+		[3]="2.065 x86 amd64"
+		[4]="2.066 x86 amd64"
+	)
+	__dlang_gdc_frontend_versionmap=(
+		[1]="4.8.1"
+		[2]="4.8.2"
+		[3]="4.8.3"
+		[4]="4.8.4"
 	)
 
 	# LDC
-	__dlang_ldc2_frontend_mapping=(
-		["0.12"]="2.063 x86 amd64"
-		["0.13"]="2.064 x86 amd64"
-		["0.14"]="2.065 x86 amd64"
-		["0.15"]="2.066 x86 amd64"
+	__dlang_ldc2_frontend_archmap=(
+		[1]="2.063 x86 amd64"
+		[2]="2.064 x86 amd64"
+		[3]="2.065 x86 amd64"
+		[4]="2.066 x86 amd64"
 	)
+	__dlang_ldc2_frontend_versionmap=(
+		[1]="0.12"
+		[2]="0.13"
+		[3]="0.14"
+		[4]="0.15"
+	)
+
+	# Error check to avoid mistyping of indices
+	if [ "${!__dlang_dmd_frontend_archmap[*]}" \
+		!= "${!__dlang_dmd_frontend_versionmap[*]}" ] ; then
+		errorstring="__dlang_dmd_frontend_archmap and "
+		errorstring+="__dlang_dmd_frontend_versionmap indices mismatch!"
+		die $errorstring
+	fi
+	if [ "${!__dlang_gdc_frontend_archmap[*]}" \
+		!= "${!__dlang_gdc_frontend_versionmap[*]}" ] ; then
+		errorstring="__dlang_gdc_frontend_archmap and "
+		errorstring+="__dlang_gdc_frontend_versionmap indices mismatch!"
+		die $errorstring
+	fi
+	if [ "${!__dlang_ldc2_frontend_archmap[*]}" \
+		!= "${!__dlang_ldc2_frontend_versionmap[*]}" ] ; then
+		errorstring="__dlang_ldc2_frontend_archmap and "
+		errorstring+="__dlang_ldc2_frontend_versionmap indices mismatch!"
+		die $errorstring
+	fi
 }
 
 fi

--- a/eclass/dlang.eclass
+++ b/eclass/dlang.eclass
@@ -333,11 +333,12 @@ __dlang_is_in_version_range() {
 }
 
 __dlang_filter_compilers() {
-	local dc_version mapping iuse
+	local indices dc_version mapping iuse
 
 	# filter for DMD
-	for dc_version in ${!__dlang_dmd_frontend_mapping[@]}; do
-		mapping=${__dlang_dmd_frontend_mapping[$dc_version]}
+	for indices in ${!__dlang_dmd_frontend_archmap[@]}; do
+		dc_version=${__dlang_dmd_frontend_versionmap[$indices]};
+		mapping=${__dlang_dmd_frontend_archmap[$indices]}
 		if __dlang_is_in_version_range "$mapping" "$1" "$2" "$KEYWORDS"; then
 			iuse=dmd-$(replace_all_version_separators _ $dc_version)
 			__dlang_compiler_iuse+=("$iuse")
@@ -350,8 +351,9 @@ __dlang_filter_compilers() {
 	done
 
 	# GDC (doesn't support sub-slots, due to low EAPI requirement)
-	for dc_version in ${!__dlang_gdc_frontend_mapping[@]}; do
-		mapping=${__dlang_gdc_frontend_mapping[$dc_version]}
+	for indices in ${!__dlang_gdc_frontend_archmap[@]}; do
+		dc_version=${__dlang_gdc_frontend_versionmap[$indices]};
+		mapping=${__dlang_gdc_frontend_archmap[$indices]}
 		if __dlang_is_in_version_range "$mapping" "$1" "$2" "$KEYWORDS"; then
 			iuse=gdc-$(replace_all_version_separators _ $dc_version)
 			__dlang_compiler_iuse+=("$iuse")
@@ -360,8 +362,9 @@ __dlang_filter_compilers() {
 	done
 
 	# filter for LDC2
-	for dc_version in ${!__dlang_ldc2_frontend_mapping[@]}; do
-		mapping=${__dlang_ldc2_frontend_mapping[$dc_version]}
+	for indices in ${!__dlang_ldc2_frontend_archmap[@]}; do
+		dc_version=${__dlang_ldc2_frontend_versionmap[$indices]};
+		mapping=${__dlang_ldc2_frontend_archmap[$indices]}
 		if __dlang_is_in_version_range "$mapping" "$1" "$2" "$KEYWORDS"; then
 			iuse=ldc2-$(replace_all_version_separators _ $dc_version)
 			__dlang_compiler_iuse+=("$iuse")

--- a/eclass/dlang.eclass
+++ b/eclass/dlang.eclass
@@ -336,9 +336,9 @@ __dlang_filter_compilers() {
 	local indices dc_version mapping iuse
 
 	# filter for DMD
-	for indices in ${!__dlang_dmd_frontend_archmap[@]}; do
-		dc_version=${__dlang_dmd_frontend_versionmap[$indices]};
-		mapping=${__dlang_dmd_frontend_archmap[$indices]}
+	for indices in "${!__dlang_dmd_frontend_archmap[@]}"; do
+		dc_version="${__dlang_dmd_frontend_versionmap[${indices}]}"
+		mapping="${__dlang_dmd_frontend_archmap[${indices}]}"
 		if __dlang_is_in_version_range "$mapping" "$1" "$2" "$KEYWORDS"; then
 			iuse=dmd-$(replace_all_version_separators _ $dc_version)
 			__dlang_compiler_iuse+=("$iuse")
@@ -351,9 +351,9 @@ __dlang_filter_compilers() {
 	done
 
 	# GDC (doesn't support sub-slots, due to low EAPI requirement)
-	for indices in ${!__dlang_gdc_frontend_archmap[@]}; do
-		dc_version=${__dlang_gdc_frontend_versionmap[$indices]};
-		mapping=${__dlang_gdc_frontend_archmap[$indices]}
+	for indices in "${!__dlang_gdc_frontend_archmap[@]}"; do
+		dc_version="${__dlang_gdc_frontend_versionmap[${indices}]}"
+		mapping="${__dlang_gdc_frontend_archmap[${indices}]}"
 		if __dlang_is_in_version_range "$mapping" "$1" "$2" "$KEYWORDS"; then
 			iuse=gdc-$(replace_all_version_separators _ $dc_version)
 			__dlang_compiler_iuse+=("$iuse")
@@ -362,9 +362,9 @@ __dlang_filter_compilers() {
 	done
 
 	# filter for LDC2
-	for indices in ${!__dlang_ldc2_frontend_archmap[@]}; do
-		dc_version=${__dlang_ldc2_frontend_versionmap[$indices]};
-		mapping=${__dlang_ldc2_frontend_archmap[$indices]}
+	for indices in "${!__dlang_ldc2_frontend_archmap[@]}"; do
+		dc_version="${__dlang_ldc2_frontend_versionmap[${indices}]}";
+		mapping="${__dlang_ldc2_frontend_archmap[${indices}]}"
 		if __dlang_is_in_version_range "$mapping" "$1" "$2" "$KEYWORDS"; then
 			iuse=ldc2-$(replace_all_version_separators _ $dc_version)
 			__dlang_compiler_iuse+=("$iuse")


### PR DESCRIPTION
As stated in issue #17  using bash 4.0 associative arrays violates the Gentoo package manager specification and causes the build to fail when using either the paludis package manager or older versions or portage, this patch fixes this and allows packages in this overlay to build with paludis. 