### PR TITLE
Move @BLURB in eclasses to single line

### DIFF
--- a/eclass/dlang-compilers.eclass
+++ b/eclass/dlang-compilers.eclass
@@ -1,7 +1,6 @@
 # @ECLASS: dlang-compilers.eclass
 # @MAINTAINER: marco.leise@gmx.de
-# @BLURB:
-# Support data for dlang.eclass
+# @BLURB: Support data for dlang.eclass
 # @DESCRIPTION:
 # Contains the available D compiler versions with their stable archs.
 

--- a/eclass/dlang.eclass
+++ b/eclass/dlang.eclass
@@ -1,7 +1,6 @@
 # @ECLASS: dlang.eclass
 # @MAINTAINER: marco.leise@gmx.de
-# @BLURB:
-# install D libraries in multiple locations for each D version and compiler
+# @BLURB: install D libraries in multiple locations for each D version and compiler
 # @DESCRIPTION:
 # The dlang eclass faciliates creating dependiencies on D libraries for use
 # with different D compilers and D versions.

--- a/eclass/dmd.eclass
+++ b/eclass/dmd.eclass
@@ -1,7 +1,6 @@
 # @ECLASS: dmd.eclass
 # @MAINTAINER: marco.leise@gmx.de
-# @BLURB:
-# Captures most of the logic for installing DMD.
+# @BLURB: Captures most of the logic for installing DMD
 # @DESCRIPTION:
 # Helps with the maintenance of the various DMD versions by capturing common
 # logic.


### PR DESCRIPTION
This is required to keep [app-portage/eclass-manpages](https://github.com/gentoo/gentoo/blob/6bf56bbc7505c5302bac82864c43377ef9b2e28a/app-portage/eclass-manpages/files/eclass-to-manpage.awk#L22) happy. That command [only parses one line](https://github.com/gentoo/gentoo/blob/6bf56bbc7505c5302bac82864c43377ef9b2e28a/app-portage/eclass-manpages/files/eclass-to-manpage.awk#L180-L181) and [complains if that is empty](https://github.com/gentoo/gentoo/blob/6bf56bbc7505c5302bac82864c43377ef9b2e28a/app-portage/eclass-manpages/files/eclass-to-manpage.awk#L262-L263):

```
 * Generating man pages from: /usr/portage/local/layman/dlang/eclass

dlang-compilers.eclass:
   error:4: dlang-compilers.eclass: no @BLURB found
FAIL: /usr/portage/local/layman/dlang/eclass/dlang-compilers.eclass

dlang.eclass:
   error:4: dlang.eclass: no @BLURB found
FAIL: /usr/portage/local/layman/dlang/eclass/dlang.eclass

dmd.eclass:
   error:4: dmd.eclass: no @BLURB found
FAIL: /usr/portage/local/layman/dlang/eclass/dmd.eclass
 * ERROR: app-portage/eclass-manpages-20170201::gentoo failed (compile phase):
 *   (no error message)
 * 
 * Call stack:
 *     ebuild.sh, line 115:  Called src_compile
 *   environment, line 206:  Called genit '/usr/portage/local/layman/dlang/eclass'
 *   environment, line 193:  Called die
 * The specific snippet of code:
 *       env ECLASSDIR=${e} bash "${FILESDIR}"/eclass-to-manpage.sh || die
```