### PR TITLE
Fix failing emerge caused by ppc-openbsd

### DIFF
--- a/eclass/dlang.eclass
+++ b/eclass/dlang.eclass
@@ -268,7 +268,7 @@ declare -a __dlang_depends
 
 __dlang_compiler_masked_archs_for_version_range() {
 	local iuse=$1
-	local depend="!ppc-aix? ( !ppc64-linux? ( !ppc-macos? ( !ppc-openbsd? ( $iuse? ( $2 ) ) ) ) )"
+	local depend="!ppc-aix? ( !ppc64-linux? ( !ppc-macos? ( $iuse? ( $2 ) ) ) )"
 	local dlang_version=${3%% *}
 	local compiler_keywords=${3:${#dlang_version}}
 	local compiler_keyword package_keyword nomatch anyworks usable arch have_one


### PR DESCRIPTION
Since c605e11ea has been commited, compilers can't be emerged, no-one
knows why the line was added, but it is known to break everything.

```
localhost ~ # emerge -avq '=dmd-2.071.2'

!!! All ebuilds that could satisfy "=dmd-2.071.2" have been masked.
!!! One of the following masked packages is required to complete your request:
- dev-lang/dmd-2.071.2::dlang (masked by: invalid: DEPEND: USE flag 'ppc-openbsd' referenced in conditional '!ppc-openbsd?' is not in IUSE, invalid: RDEPEND: USE flag 'ppc-openbsd' referenced in conditional '!ppc-openbsd?' is not in IUSE)

For more information, see the MASKED PACKAGES section in the emerge
man page or refer to the Gentoo Handbook.
```

If you ever decide to add it back, explain in commits why! And test that
the packages actually build!