### PR TITLE
x11-terms/tilix: depend on app-text/po4a

### DIFF
--- a/x11-terms/tilix/tilix-1.5.6.ebuild
+++ b/x11-terms/tilix/tilix-1.5.6.ebuild
@@ -27,7 +27,9 @@ RDEPEND="
 	x11-libs/vte:2.91[crypt?]"
 DEPEND="
 	>=sys-devel/autoconf-2.69
-	sys-devel/automake:1.15 ${DEPEND}"
+	sys-devel/automake:1.15
+	app-text/po4a
+	${RDEPEND}"
 
 src_prepare() {
 	eapply_user

--- a/x11-terms/tilix/tilix-1.6.1.ebuild
+++ b/x11-terms/tilix/tilix-1.6.1.ebuild
@@ -27,7 +27,9 @@ RDEPEND="
 	x11-libs/vte:2.91[crypt?]"
 DEPEND="
 	>=sys-devel/autoconf-2.69
-	sys-devel/automake:1.15 ${DEPEND}"
+	sys-devel/automake:1.15
+	app-text/po4a
+	${RDEPEND}"
 
 src_prepare() {
 	eapply_user


### PR DESCRIPTION
As we can see [here](https://github.com/gnunn1/tilix/blob/master/configure.ac#L28-L32), the build process fail without app-text/po4a.