### PR TITLE
Miscellaneous small improvements

### DIFF
--- a/dev-lang/dmd/dmd-2.086.0.ebuild
+++ b/dev-lang/dmd/dmd-2.086.0.ebuild
@@ -20,5 +20,5 @@ dmd_src_prepare_extra() {
 	cp "${FILESDIR}/2.086-default_ddoc_theme.ddoc" "dmd/res/default_ddoc_theme.ddoc" || die "Failed to copy 'default_ddoc_theme.ddoc' file into 'src/res' directory."
 
 	# Copy missing config.d
-	cp "${FILESDIR}/2.086-config.d" "dmd/config.d" || die "Failed to copy 'config.sh' file into 'dmd' directory."
+	cp "${FILESDIR}/2.086-config.d" "dmd/config.d" || die "Failed to copy 'config.d' file into 'dmd' directory."
 }

--- a/eclass/dlang.eclass
+++ b/eclass/dlang.eclass
@@ -220,7 +220,7 @@ dlang_convert_ldflags() {
 		# gc-sections breaks executables for some versions of D
 		# It works with the gold linker on the other hand
 		# See: https://issues.dlang.org/show_bug.cgi?id=879
-		[[ "${DLANG_PACKAGE_TYPE}" = "dmd" ]] && local dlang_version=$SLOT || local dlang_version=$DLANG_VERSION
+		[[ "${DLANG_PACKAGE_TYPE}" == "dmd" ]] && local dlang_version=$SLOT || local dlang_version=$DLANG_VERSION
 		if ver_test $dlang_version -lt 2.072; then
 			if ! ld -v | grep -q "^GNU gold"; then
 				filter-ldflags {-L,-Xlinker,-Wl,}--gc-sections

--- a/eclass/dlang.eclass
+++ b/eclass/dlang.eclass
@@ -320,7 +320,11 @@ __dlang_compiler_masked_archs_for_version_range() {
 	# RDEPEND.
 
 	local iuse=$1
-	local depend="$iuse? ( $2 )"
+	if [[ "${DLANG_PACKAGE_TYPE}" == "dmd" ]] && [[ "$iuse" == gdc* ]]; then
+		local depend="$iuse? ( $2 "=dev-util/gdmd-$(ver_rs 1-2 . ${iuse#gdc-})*" )"
+	else
+		local depend="$iuse? ( $2 )"
+	fi
 	local dlang_version=${3%% *}
 	local compiler_keywords=${3:${#dlang_version}}
 	local compiler_keyword package_keyword arch

--- a/eclass/dmd.eclass
+++ b/eclass/dmd.eclass
@@ -196,7 +196,7 @@ EOF
 	elif [ "${ABI:0:5}" = "amd64" ]; then
 		cat > linux/bin${MODEL}/dmd.conf << EOF
 [Environment]
-DFLAGS=-I${IMPORT_DIR} -L--export-dynamic -defaultlib=phobos2 -L-L/${PREFIX}/lib64 -L-rpath -L/${PREFIX}/lib64
+DFLAGS=-I${IMPORT_DIR} -L--export-dynamic -defaultlib=phobos2 -fPIC -L-L/${PREFIX}/lib64 -L-rpath -L/${PREFIX}/lib64
 EOF
 	else
 		cat > linux/bin${MODEL}/dmd.conf << EOF


### PR DESCRIPTION
Due to the upcoming Funtoo 1.4 natively supporting D 2.076 through GDC's integration in GCC 9 I've soft forked this overlay to [Funtoo's infrastructure](https://code.funtoo.org/bitbucket/users/calrama/repos/dlang-overlay/browse) where that difference'll be reflected.
These are just some quality of life changes I've made that I think upstream would profit from having.