### PR TITLE
Install to /usr/lib/ instead of /opt

### DIFF
--- a/app-eselect/eselect-dlang/eselect-dlang-20190608.ebuild
+++ b/app-eselect/eselect-dlang/eselect-dlang-20190608.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/app-eselect/eselect-dlang/files/dlang.eselect-20190608
+++ b/app-eselect/eselect-dlang/files/dlang.eselect-20190608
@@ -1,12 +1,12 @@
 # -*-eselect-*-  vim: ft=eselect
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 inherit config
 
 DESCRIPTION="Manage D symlinks"
 MAINTAINER="marco.leise@gmx.de"
-VERSION="20181021"
+VERSION="20190608"
 
 ETC_PATH="${EROOT}/etc"
 COMPILER_PATH="${EROOT}/usr/bin"
@@ -103,16 +103,16 @@ do_set() {
 
 	case $1 in
 		dmd)
-			symlink_helper "${EROOT}/opt/dmd-${target}/bin/dmd"      "${COMPILER_PATH}/dmd"
-			symlink_helper "${EROOT}/opt/dmd-${target}/bin/dmd.conf" "${ETC_PATH}/dmd.conf"
-			symlink_helper "${EROOT}/opt/dmd-${target}/import"       "${INC_PATH}/dmd"
-			[[ -d ${MAN1_PATH} ]] && symlink_helper "/opt/dmd-${target}/man/man1/dmd.1"      "${MAN1_PATH}/dmd.1"
-			[[ -d ${MAN5_PATH} ]] && symlink_helper "/opt/dmd-${target}/man/man5/dmd.conf.5" "${MAN5_PATH}/dmd.conf.5"
+			symlink_helper "${EROOT}/usr/lib/dmd/${target}/bin/dmd"      "${COMPILER_PATH}/dmd"
+			symlink_helper "${EROOT}/usr/lib/dmd/${target}/bin/dmd.conf" "${ETC_PATH}/dmd.conf"
+			symlink_helper "${EROOT}/usr/lib/dmd/${target}/import"       "${INC_PATH}/dmd"
+			[[ -d ${MAN1_PATH} ]] && symlink_helper "/usr/lib/dmd/${target}/man/man1/dmd.1"      "${MAN1_PATH}/dmd.1"
+			[[ -d ${MAN5_PATH} ]] && symlink_helper "/usr/lib/dmd/${target}/man/man5/dmd.conf.5" "${MAN5_PATH}/dmd.conf.5"
 			;;
 		ldc2)
-			symlink_helper "${EROOT}/opt/ldc2-${target}/bin/ldc2"  "${COMPILER_PATH}/ldc2"
-			symlink_helper "${EROOT}/opt/ldc2-${target}/bin/ldmd2" "${COMPILER_PATH}/ldmd2"
-			symlink_helper "${EROOT}/opt/ldc2-${target}/include/d" "${INC_PATH}/ldc"
+			symlink_helper "${EROOT}/usr/lib/ldc2/${target}/bin/ldc2"  "${COMPILER_PATH}/ldc2"
+			symlink_helper "${EROOT}/usr/lib/ldc2/${target}/bin/ldmd2" "${COMPILER_PATH}/ldmd2"
+			symlink_helper "${EROOT}/usr/lib/ldc2/${target}/include/d" "${INC_PATH}/ldc"
 			;;
 	esac
 	store_config "$CONFIG_FILE" $1 "$2"
@@ -141,7 +141,7 @@ do_show() {
 	[[ $# -eq 1 ]] && has "$1" ${!COMPILER_NAMES[@]} \
 		|| die -q "1 argument required: eselect dlang show $(compiler_options)"
 
-	local interpreter="$(readlink "${COMPILER_PATH}/$1" | sed "s#^/opt/$1-##;s#/bin/$1\$##")"
+	local interpreter="$(readlink "${COMPILER_PATH}/$1" | sed -r "s#^/usr/lib(32|64)?/$1/##;s#/bin/$1\$##")"
 	[[ -n "$interpreter" ]] && echo "$interpreter"
 }
 
@@ -210,10 +210,10 @@ do_update() {
 find_targets() {
 	case "$1" in
 		dmd)
-			ls /opt/dmd-?.???/bin/dmd 2> /dev/null | sed "s#^/opt/dmd-##;s#/.*##"
+			ls /usr/lib/dmd/?.???/bin/dmd 2> /dev/null | sed "s#^/usr/lib/dmd/##;s#/.*##"
 			;;
 		ldc2)
-			ls -v /opt/ldc2-?.*/bin/ldc2 2> /dev/null | sed "s#^/opt/ldc2-##;s#/.*##"
+			ls -v /usr/lib/ldc2/?.*/bin/ldc2 2> /dev/null | sed "s#^/usr/lib/ldc2/##;s#/.*##"
 			;;
 		*)
 			die "Unknown compiler '$1'"

--- a/dev-lang/ldc2/ldc2-0.17.5-r1.ebuild
+++ b/dev-lang/ldc2/ldc2-0.17.5-r1.ebuild
@@ -46,7 +46,7 @@ src_configure() {
 	fi
 	local mycmakeargs=(
 		-DD_VERSION=2
-		-DCMAKE_INSTALL_PREFIX=/opt/ldc2-$(ver_cut 1-2)
+		-DCMAKE_INSTALL_PREFIX=/usr/lib/ldc2/$(ver_cut 1-2)
 	)
 	use abi_x86_32 && use abi_x86_64 && mycmakeargs+=( -DMULTILIB=ON )
 	detect_hardened && mycmakeargs+=( -DADDITIONAL_DEFAULT_LDC_SWITCHES=', "-relocation-model=pic"' )

--- a/dev-lang/ldc2/ldc2-0.17.6.ebuild
+++ b/dev-lang/ldc2/ldc2-0.17.6.ebuild
@@ -48,7 +48,7 @@ src_configure() {
 	fi
 	local mycmakeargs=(
 		-DD_VERSION=2
-		-DCMAKE_INSTALL_PREFIX=/opt/ldc2-$(ver_cut 1-2)
+		-DCMAKE_INSTALL_PREFIX=/usr/lib/ldc2/$(ver_cut 1-2)
 	)
 	use abi_x86_32 && use abi_x86_64 && mycmakeargs+=( -DMULTILIB=ON )
 	detect_hardened && mycmakeargs+=( -DADDITIONAL_DEFAULT_LDC_SWITCHES=', "-relocation-model=pic"' )

--- a/dev-lang/ldc2/ldc2-1.10.0.ebuild
+++ b/dev-lang/ldc2/ldc2-1.10.0.ebuild
@@ -53,7 +53,7 @@ d_src_configure() {
 	export LIBDIR_${ABI}="${LIBDIR_HOST}"
 	local mycmakeargs=(
 		-DD_VERSION=2
-		-DCMAKE_INSTALL_PREFIX=/opt/ldc2-$(ver_cut 1-2)
+		-DCMAKE_INSTALL_PREFIX=/usr/lib/ldc2/$(ver_cut 1-2)
 		-DD_COMPILER="${DMD}"
 		-DD_COMPILER_DMD_COMPAT=1
 		-DLDC_WITH_LLD=OFF

--- a/dev-lang/ldc2/ldc2-1.11.0.ebuild
+++ b/dev-lang/ldc2/ldc2-1.11.0.ebuild
@@ -53,7 +53,7 @@ d_src_configure() {
 	export LIBDIR_${ABI}="${LIBDIR_HOST}"
 	local mycmakeargs=(
 		-DD_VERSION=2
-		-DCMAKE_INSTALL_PREFIX=/opt/ldc2-$(ver_cut 1-2)
+		-DCMAKE_INSTALL_PREFIX=/usr/lib/ldc2/$(ver_cut 1-2)
 		-DD_COMPILER="${DMD}"
 		-DD_COMPILER_DMD_COMPAT=1
 		-DLDC_WITH_LLD=OFF

--- a/dev-lang/ldc2/ldc2-1.12.0-r1.ebuild
+++ b/dev-lang/ldc2/ldc2-1.12.0-r1.ebuild
@@ -55,7 +55,7 @@ d_src_configure() {
 	export LIBDIR_${ABI}="${LIBDIR_HOST}"
 	local mycmakeargs=(
 		-DD_VERSION=2
-		-DCMAKE_INSTALL_PREFIX=/opt/ldc2-$(ver_cut 1-2)
+		-DCMAKE_INSTALL_PREFIX=/usr/lib/ldc2/$(ver_cut 1-2)
 		-DD_COMPILER="${DMD}"
 		-DD_COMPILER_DMD_COMPAT=1
 		-DLDC_WITH_LLD=OFF

--- a/dev-lang/ldc2/ldc2-1.13.0-r1.ebuild
+++ b/dev-lang/ldc2/ldc2-1.13.0-r1.ebuild
@@ -55,7 +55,7 @@ d_src_configure() {
 	export LIBDIR_${ABI}="${LIBDIR_HOST}"
 	local mycmakeargs=(
 		-DD_VERSION=2
-		-DCMAKE_INSTALL_PREFIX=/opt/ldc2-$(ver_cut 1-2)
+		-DCMAKE_INSTALL_PREFIX=/usr/lib/ldc2/$(ver_cut 1-2)
 		-DD_COMPILER="${DMD}"
 		-DD_COMPILER_DMD_COMPAT=1
 		-DLDC_WITH_LLD=OFF

--- a/dev-lang/ldc2/ldc2-1.14.0-r1.ebuild
+++ b/dev-lang/ldc2/ldc2-1.14.0-r1.ebuild
@@ -55,7 +55,7 @@ d_src_configure() {
 	export LIBDIR_${ABI}="${LIBDIR_HOST}"
 	local mycmakeargs=(
 		-DD_VERSION=2
-		-DCMAKE_INSTALL_PREFIX=/opt/ldc2-$(ver_cut 1-2)
+		-DCMAKE_INSTALL_PREFIX=/usr/lib/ldc2/$(ver_cut 1-2)
 		-DD_COMPILER="${DMD}"
 		-DD_COMPILER_DMD_COMPAT=1
 		-DLDC_WITH_LLD=OFF

--- a/dev-lang/ldc2/ldc2-1.15.0-r1.ebuild
+++ b/dev-lang/ldc2/ldc2-1.15.0-r1.ebuild
@@ -56,7 +56,7 @@ d_src_configure() {
 	export LIBDIR_${ABI}="${LIBDIR_HOST}"
 	local mycmakeargs=(
 		-DD_VERSION=2
-		-DCMAKE_INSTALL_PREFIX=/opt/ldc2-$(ver_cut 1-2)
+		-DCMAKE_INSTALL_PREFIX=/usr/lib/ldc2/$(ver_cut 1-2)
 		-DD_COMPILER="${DMD}"
 		-DD_COMPILER_DMD_COMPAT=1
 		-DLDC_WITH_LLD=OFF

--- a/dev-lang/ldc2/ldc2-1.4.0-r1.ebuild
+++ b/dev-lang/ldc2/ldc2-1.4.0-r1.ebuild
@@ -59,7 +59,7 @@ d_src_configure() {
 	export LIBDIR_${ABI}="${LIBDIR_HOST}"
 	local mycmakeargs=(
 		-DD_VERSION=2
-		-DCMAKE_INSTALL_PREFIX=/opt/ldc2-$(ver_cut 1-2)
+		-DCMAKE_INSTALL_PREFIX=/usr/lib/ldc2/$(ver_cut 1-2)
 		-DD_COMPILER="${DMD}"
 		-DD_COMPILER_DMD_COMPAT=1
 	)

--- a/dev-lang/ldc2/ldc2-1.5.0-r1.ebuild
+++ b/dev-lang/ldc2/ldc2-1.5.0-r1.ebuild
@@ -59,7 +59,7 @@ d_src_configure() {
 	export LIBDIR_${ABI}="${LIBDIR_HOST}"
 	local mycmakeargs=(
 		-DD_VERSION=2
-		-DCMAKE_INSTALL_PREFIX=/opt/ldc2-$(ver_cut 1-2)
+		-DCMAKE_INSTALL_PREFIX=/usr/lib/ldc2/$(ver_cut 1-2)
 		-DD_COMPILER="${DMD}"
 		-DD_COMPILER_DMD_COMPAT=1
 	)

--- a/dev-lang/ldc2/ldc2-1.6.0-r1.ebuild
+++ b/dev-lang/ldc2/ldc2-1.6.0-r1.ebuild
@@ -59,7 +59,7 @@ d_src_configure() {
 	export LIBDIR_${ABI}="${LIBDIR_HOST}"
 	local mycmakeargs=(
 		-DD_VERSION=2
-		-DCMAKE_INSTALL_PREFIX=/opt/ldc2-$(ver_cut 1-2)
+		-DCMAKE_INSTALL_PREFIX=/usr/lib/ldc2/$(ver_cut 1-2)
 		-DD_COMPILER="${DMD}"
 		-DD_COMPILER_DMD_COMPAT=1
 	)

--- a/dev-lang/ldc2/ldc2-1.7.0-r1.ebuild
+++ b/dev-lang/ldc2/ldc2-1.7.0-r1.ebuild
@@ -59,7 +59,7 @@ d_src_configure() {
 	export LIBDIR_${ABI}="${LIBDIR_HOST}"
 	local mycmakeargs=(
 		-DD_VERSION=2
-		-DCMAKE_INSTALL_PREFIX=/opt/ldc2-$(ver_cut 1-2)
+		-DCMAKE_INSTALL_PREFIX=/usr/lib/ldc2/$(ver_cut 1-2)
 		-DD_COMPILER="${DMD}"
 		-DD_COMPILER_DMD_COMPAT=1
 	)

--- a/dev-lang/ldc2/ldc2-1.8.0-r1.ebuild
+++ b/dev-lang/ldc2/ldc2-1.8.0-r1.ebuild
@@ -59,7 +59,7 @@ d_src_configure() {
 	export LIBDIR_${ABI}="${LIBDIR_HOST}"
 	local mycmakeargs=(
 		-DD_VERSION=2
-		-DCMAKE_INSTALL_PREFIX=/opt/ldc2-$(ver_cut 1-2)
+		-DCMAKE_INSTALL_PREFIX=/usr/lib/ldc2/$(ver_cut 1-2)
 		-DD_COMPILER="${DMD}"
 		-DD_COMPILER_DMD_COMPAT=1
 	)

--- a/dev-lang/ldc2/ldc2-1.9.0.ebuild
+++ b/dev-lang/ldc2/ldc2-1.9.0.ebuild
@@ -53,7 +53,7 @@ d_src_configure() {
 	export LIBDIR_${ABI}="${LIBDIR_HOST}"
 	local mycmakeargs=(
 		-DD_VERSION=2
-		-DCMAKE_INSTALL_PREFIX=/opt/ldc2-$(ver_cut 1-2)
+		-DCMAKE_INSTALL_PREFIX=/usr/lib/ldc2/$(ver_cut 1-2)
 		-DD_COMPILER="${DMD}"
 		-DD_COMPILER_DMD_COMPAT=1
 		-DLDC_WITH_LLD=OFF

--- a/eclass/dlang.eclass
+++ b/eclass/dlang.eclass
@@ -46,11 +46,14 @@ dlang-compilers_declare_versions
 # ABI: See 'multilib_get_enabled_abis' from multilib-build.eclass.
 # MODEL: This is either 32 or 64.
 # DLANG_VENDOR: Either DigitalMars, GNU or LDC.
-# DC: D compiler command. E.g. /opt/dmd-2.067/bin/dmd, /opt/ldc2-0.12.0/bin/ldc2
-#   or /usr/x86_64-pc-linux-gnu/gcc-bin/4.8.1/x86_64-pc-linux-gnu-gdc
-# DMD: DMD compiler command. E.g. /opt/dmd-2.069/bin/dmd,
-#   /opt/ldc2-0.16/bin/ldmd2 or
-#   /usr/x86_64-pc-linux-gnu/gcc-bin/4.8.4/x86_64-pc-linux-gnu-gdmd
+# DC: D compiler command. E.g.
+#   /usr/x86_64-pc-linux-gnu/gcc-bin/9.1.1/x86_64-pc-linux-gnu-gdc,
+#   /usr/lib/dmd/2.067/bin/dmd, or
+#   /usr/lib/ldc2/0.17/bin/ldc2
+# DMD: DMD compiler command. E.g.
+#   /usr/x86_64-pc-linux-gnu/gcc-bin/9.1.1/x86_64-pc-linux-gnu-gdmd,
+#   /usr/lib/dmd/2.086/bin/dmd, or
+#   /usr/lib/ldc2/0.17/bin/ldmd2
 # DC_VERSION: Release version of the compiler. This is the version excluding any
 #   Patch releases. So dmd 2.064.2 would still be 2.064. This version is used
 #   to separate potentially incompatible ABIs and to create the library path.
@@ -269,12 +272,12 @@ dlang_convert_ldflags() {
 # paths.
 dlang_system_imports() {
 	if [[ "${DLANG_VENDOR}" == "DigitalMars" ]]; then
-		echo "/opt/dmd-${DC_VERSION}/import"
+		echo "/usr/lib/dmd/${DC_VERSION}/import"
 	elif [[ "${DLANG_VENDOR}" == "GNU" ]]; then
 		echo "/usr/lib/gcc/${CHOST_default}/${DC_VERSION}/include/d"
 	elif [[ "${DLANG_VENDOR}" == "LDC" ]]; then
-		echo "/opt/ldc2-${DC_VERSION}/include/d"
-		echo "/opt/ldc2-${DC_VERSION}/include/d/ldc"
+		echo "/usr/lib/ldc2/${DC_VERSION}/include/d"
+		echo "/usr/lib/ldc2/${DC_VERSION}/include/d/ldc"
 	else
 		die "Could not detect D compiler vendor!"
 	fi
@@ -574,14 +577,14 @@ __dlang_use_build_vars() {
 	esac
 	if [[ "${DLANG_VENDOR}" == "DigitalMars" ]]; then
 		if [ "${DC_VERSION}" != "selfhost" ]; then
-			export DC="/opt/${DC}-${DC_VERSION}/bin/dmd"
+			export DC="/usr/lib/dmd/${DC_VERSION}/bin/dmd"
 			export DMD="${DC}"
 		fi
 		# "lib" on pure x86, "lib{32,64}" on amd64 (and multilib)
 		if has_multilib_profile || [[ "${MODEL}" == "64" ]]; then
-			export LIBDIR_${ABI}="../opt/dmd-${DC_VERSION}/lib${MODEL}"
+			export LIBDIR_${ABI}="../usr/lib/dmd/${DC_VERSION}/lib${MODEL}"
 		else
-			export LIBDIR_${ABI}="../opt/dmd-${DC_VERSION}/lib"
+			export LIBDIR_${ABI}="../usr/lib/dmd/${DC_VERSION}/lib"
 		fi
 		export DCFLAGS="${DMDFLAGS}"
 		export DLANG_LINKER_FLAG="-L"
@@ -609,9 +612,9 @@ __dlang_use_build_vars() {
 		export DLANG_VERSION_FLAG="-fversion"
 		export DLANG_UNITTEST_FLAG="-funittest"
 	elif [[ "${DLANG_VENDOR}" == "LDC" ]]; then
-		export LIBDIR_${ABI}="../opt/${DC}-${DC_VERSION}/lib${MODEL}"
-		export DMD="/opt/${DC}-${DC_VERSION}/bin/ldmd2"
-		export DC="/opt/${DC}-${DC_VERSION}/bin/ldc2"
+		export LIBDIR_${ABI}="../usr/lib/ldc2/${DC_VERSION}/lib${MODEL}"
+		export DMD="/usr/lib/ldc2/${DC_VERSION}/bin/ldmd2"
+		export DC="/usr/lib/ldc2/${DC_VERSION}/bin/ldc2"
 		# To allow separate compilation and avoid object file name collisions,
 		# we append -op (do not strip paths from source file).
 		export DCFLAGS="${LDCFLAGS} -op"

--- a/eclass/dmd.eclass
+++ b/eclass/dmd.eclass
@@ -89,7 +89,7 @@ RDEPEND="
 PDEPEND="tools? ( >=dev-util/dlang-tools-${PV} )"
 
 S="${WORKDIR}/dmd2"
-PREFIX="opt/${PN}-${SLOT}"
+PREFIX="usr/lib/${PN}/${SLOT}"
 IMPORT_DIR="/${PREFIX}/import"
 
 dmd_src_prepare() {
@@ -206,7 +206,7 @@ EOF
 	fi
 	insinto "etc/dmd"
 	newins "linux/bin${MODEL}/dmd.conf" "${SLOT}.conf"
-	dosym "../../../etc/dmd/${SLOT}.conf" "${PREFIX}/bin/dmd.conf"
+	dosym "../../../../../etc/dmd/${SLOT}.conf" "${PREFIX}/bin/dmd.conf"
 
 	# DMD
 	einfo "Installing ${PN}..."
@@ -227,22 +227,22 @@ EOF
 	install_phobos_2() {
 		# Copied get_libdir logic from dlang.eclass, so we can install Phobos correctly.
 		if has_multilib_profile || [[ "${MODEL}" == "64" ]]; then
-			local libdir="../opt/dmd-${SLOT}/lib${MODEL}"
+			local libdir="../${PREFIX}/lib${MODEL}"
 		else
-			local libdir="../opt/dmd-${SLOT}/lib"
+			local libdir="../${PREFIX}/lib"
 		fi
 
 		# Install shared lib.
 		dolib.so phobos/generated/linux/release/${MODEL}/"${SONAME}"
 		dosym "${SONAME}" /usr/"$(get_libdir)"/"${SONAME_SYM}"
-		dosym ../../../usr/"$(get_libdir)"/"${SONAME}" /usr/"${libdir}"/libphobos2.so
+		dosym ../../../../../usr/"$(get_libdir)"/"${SONAME}" /usr/"${libdir}"/libphobos2.so
 
 		# Install static lib if requested.
 		if use static-libs; then
 			if has_multilib_profile || [[ "${MODEL}" == "64" ]]; then
-				export LIBDIR_${ABI}="../opt/dmd-${SLOT}/lib${MODEL}"
+				export LIBDIR_${ABI}="../${PREFIX}/lib${MODEL}"
 			else
-				export LIBDIR_${ABI}="../opt/dmd-${SLOT}/lib"
+				export LIBDIR_${ABI}="../${PREFIX}/lib"
 			fi
 			dolib.a phobos/generated/linux/release/${MODEL}/libphobos2.a
 		fi

--- a/metadata/news/2019-06-12-install-compilers-into-usr-lib/2019-06-12-install-compilers-into-usr-lib.en.txt
+++ b/metadata/news/2019-06-12-install-compilers-into-usr-lib/2019-06-12-install-compilers-into-usr-lib.en.txt
@@ -1,0 +1,11 @@
+Title: D compilers now installed to /usr/lib
+Author: Moritz Maxeiner <moritz.maxeiner@gmail.com>
+Content-Type: text/plain
+Posted: 2019-06-12
+Revision: 1
+News-Item-Format: 2.0
+Display-If-Installed: dev-lang/dmd
+Display-If-Installed: dev-lang/ldc2
+
+As of now the D compilers dmd and ldc2 will be installed into
+'/usr/lib/{dmd,ldc2}/$version' instead of '/opt/{dmd,ldc2}-$version'.


### PR DESCRIPTION
As discussed in https://github.com/gentoo/dlang/pull/78 here are the changes required to install D compilers to `/usr/lib/$catpkg/$version` instead of `/opt/$catpkg-$version`.
Please be advised that I only tested `ldc2-0.17.6`, `ldc2-1.15.0`, `dmd-2.067.1`, and `dmd-2.086.0`, as I currently only support these packages downstream.
