### PR TITLE
Add git as a build dependency for some dmd ebuilds

### DIFF
--- a/dev-lang/dmd/dmd-2.084.1-r2.ebuild
+++ b/dev-lang/dmd/dmd-2.084.1-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,6 +6,8 @@ EAPI=6
 KEYWORDS="-* amd64 x86"
 YEAR=2019
 DLANG_VERSION_RANGE="2.073-2.091"
+
+DEPEND='dev-vcs/git'
 
 inherit dmd
 

--- a/dev-lang/dmd/dmd-2.085.1-r2.ebuild
+++ b/dev-lang/dmd/dmd-2.085.1-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,6 +6,8 @@ EAPI=6
 KEYWORDS="-* amd64 x86"
 YEAR=2019
 DLANG_VERSION_RANGE="2.073-"
+
+DEPEND='dev-vcs/git'
 
 inherit dmd
 

--- a/dev-lang/dmd/dmd-2.086.1-r1.ebuild
+++ b/dev-lang/dmd/dmd-2.086.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,6 +6,8 @@ EAPI=6
 KEYWORDS="-* amd64 x86"
 YEAR=2019
 DLANG_VERSION_RANGE="2.073-"
+
+DEPEND='dev-vcs/git'
 
 inherit dmd
 

--- a/dev-lang/dmd/dmd-2.087.1-r1.ebuild
+++ b/dev-lang/dmd/dmd-2.087.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -6,6 +6,8 @@ EAPI=6
 KEYWORDS="-* amd64 x86"
 YEAR=2019
 DLANG_VERSION_RANGE="2.075-"
+
+DEPEND='dev-vcs/git'
 
 inherit dmd
 


### PR DESCRIPTION
Dmd ebuilds 2.084-2.087 throw an exception that `git` was not found when trying to build:
```
../../linux/bin64/dmd ../config.d -of../generated/linux/release/64/version_check
std.process.ProcessException@std/process.d(379): Executable file not found: git
----------------
??:? @trusted std.process.Pid std.process.spawnProcessImpl(scope const(char[])[], std.stdio.File, std.stdio.File, std.stdio.File, scope const(immutable(char)[][immutable(char)[]]), std.process.Config, const(char)[]) [0x699cdc2f]
??:? @trusted std.process.Pid std.process.spawnProcess(scope const(char[])[], std.stdio.File, std.stdio.File, std.stdio.File, const(immutable(char)[][immutable(char)[]]), std.process.Configconst , char[]) [0x699cd8eb]
??:? @trusted std.process.ProcessPipes std.process.pipeProcessImpl!(std.process.spawnProcess, const(char[])[]).pipeProcessImpl(const(char[])[], std.process.Redirect, const(immutable(char)[][immutable(char)[]]), std.process.Config, const(char)[]) [0x699ae0b7]
??:? @safe std.process.ProcessPipes std.process.pipeProcess(scope const(char[])[], std.process.Redirect, const(immutable(char)[][immutable(char)[]]), std.process.Config, const(char)[]) [0x699ad570]
??:? std.typecons.Tuple!(int, "status", immutable(char)[], "output").Tuple std.process.executeImpl!(std.process.pipeProcess, const(char[])[]).executeImpl(const(char[])[], const(immutable(char)[][immutable(char)[]]), std.process.Config, ulong, scope const(char)[]) [0x6997dc82]
??:? @trusted std.typecons.Tuple!(int, "status", immutable(char)[], "output").Tuple std.process.execute(scope const(char[])[],
const(immutable(char)[][immutable(char)[]]), std.process.Config, ulong, scope const(char)[]) [0x6997d47c]
??:? immutable(char)[] config.generateVersion(const(immutable(char)[])) [0x6995cbe3]
??:? _Dmain [0x6995ca8e]
make: *** [posix.mak:552: ../generated/linux/release/64/VERSION] Error 1
make: Leaving directory '/var/tmp/portage/dev-lang/dmd-2.084.1-r2/work/dmd2/dmd/src'
 * ERROR: dev-lang/dmd-2.084.1-r2::dlang failed (compile phase):
 *   emake failed
```

When `dev-vcs/git` is installed the build works fine.