### PR TITLE
Fixes gentoo/dlang#96

### DIFF
--- a/x11-terms/tilix/tilix-1.9.3-r2.ebuild
+++ b/x11-terms/tilix/tilix-1.9.3-r2.ebuild
@@ -24,7 +24,7 @@ RDEPEND="
 	>=dev-libs/gtkd-3.8.5:3[vte,${DLANG_COMPILER_USE}]
 	x11-libs/vte:2.91[crypt?]"
 DEPEND="
-	sys-devel/automake:1.15
+	sys-devel/automake:1.16
 	>=sys-devel/autoconf-2.69
 	app-text/po4a
 	${RDEPEND}"


### PR DESCRIPTION
x11-terms/tilix: use autoconf:1.16