### PR TITLE
Add gdc 11.3.0 (improved)

### DIFF
--- a/dev-util/gdmd/gdmd-11.3.0.ebuild
+++ b/dev-util/gdmd/gdmd-11.3.0.ebuild
@@ -1,0 +1,27 @@
+# Copyright 1999-2022 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="Wrapper script for gdc that emulates the dmd command"
+HOMEPAGE="https://www.gdcproject.org/"
+LICENSE="GPL-3+"
+
+SLOT="${PV}"
+KEYWORDS="~alpha amd64 arm arm64 ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 x86"
+RDEPEND="=sys-devel/gcc-${PV}*[d]"
+RELEASE="0.1.0"
+SRC_URI="https://codeload.github.com/D-Programming-GDC/gdmd/tar.gz/script-${RELEASE} -> gdmd-${RELEASE}.tar.gz"
+PATCHES="${FILESDIR}/${PN}-no-dmd-conf.patch"
+S="${WORKDIR}/gdmd-script-${RELEASE}"
+
+src_compile() {
+	:
+}
+
+src_install() {
+	local binPath="usr/${CHOST}/gcc-bin/${PV}"
+	exeinto "${binPath}"
+	newexe dmd-script "${CHOST}-gdmd"
+	ln -f "${D}/${binPath}/${CHOST}-gdmd" "${D}/${binPath}/gdmd" || die "Could not create 'gdmd' hardlink"
+}

--- a/eclass/dlang-compilers.eclass
+++ b/eclass/dlang-compilers.eclass
@@ -55,6 +55,7 @@ dlang-compilers_declare_versions() {
 	# GDC (hppa, sparc: masked "d" USE-flag)
 	__dlang_gdc_frontend=(
 		["11.2.1"]="2.076 amd64 arm arm64 ~ia64 ~m68k ~mips ppc ~ppc64 ~riscv ~s390 x86"
+		["11.3.0"]="2.076 ~alpha amd64 arm arm64 ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 x86"
 	)
 
 	# LDC

--- a/eclass/dlang.eclass
+++ b/eclass/dlang.eclass
@@ -234,6 +234,37 @@ dlang_convert_ldflags() {
 	fi
 }
 
+# @FUNCTION: dlang_dmdw_dcflags
+# @DESCRIPTION:
+# Convertes compiler specific $DCFLAGS to something that can be passed to the
+# dmd wrapper of said compiler. Calls `die` if the flags could not be
+# converted.
+dlang_dmdw_dcflags() {
+	if [[ "${DLANG_VENDOR}" == "DigitalMars" ]]; then
+		# There's no translation that needs to be done.
+		echo "${DCFLAGS}"
+	elif [[ "${DLANG_VENDOR}" == "LDC" ]]; then
+		# ldmd2 passes all the arguments that it doesn't understand to ldc2.
+		echo "${DCFLAGS}"
+	elif [[ "${DLANG_VENDOR}" == "GNU" ]]; then
+		# From `gdmd --help`:   -q,arg1,...    pass arg1, arg2, etc. to gdc
+		if [[ "${DCFLAGS}" =~ .*,.* ]]; then
+			eerror "DCFLAGS (${DCFLAGS}) contain a comma and can not be passed to gdmd."
+			eerror "Please remove the comma, use a different compiler, or call gdc directly."
+			die "DCFLAGS contain an unconvertable comma."
+		fi
+
+		local set flags=()
+		for set in ${DCFLAGS}; do
+			flags+=("-q,${set}")
+		done
+		echo "${flags[@]}"
+	else
+		die "Set DLANG_VENDOR to DigitalMars, LDC or GNU prior to calling ${FUNCNAME}()."
+	fi
+}
+
+
 # @FUNCTION: dlang_system_imports
 # @DESCRIPTION:
 # Returns a list of standard system import paths (one per line) for the current

--- a/eclass/dmd.eclass
+++ b/eclass/dmd.eclass
@@ -103,6 +103,8 @@ dmd_src_prepare() {
 	ln -s ../druntime src/druntime || die "Failed to symlink 'druntime' to 'src/druntime'"
 	ln -s ../phobos   src/phobos   || die "Failed to symlink 'phobos' to 'src/phobos'"
 
+	mkdir dmd/generated || die "Could not create output directory"
+
 	# Convert line-endings of file-types that start as cr-lf and are installed later on
 	for file in $( find . -name "*.txt" -o -name "*.html" -o -name "*.d" -o -name "*.di" -o -name "*.ddoc" -type f ); do
 		edos2unix $file || die "Failed to convert DOS line-endings to Unix."
@@ -153,9 +155,9 @@ dmd_src_compile() {
 	fi
 	if dmd_ge 2.094; then
 		einfo "Building dmd build script..."
-		DC="${DMD}" dlang_compile_bin dmd/generated/build dmd/src/build.d
+		dlang_compile_bin dmd/generated/build dmd/src/build.d
 		einfo "Building dmd..."
-		env VERBOSE=1 ${HOST_DMD}="${DMD}" CXX="$(tc-getCXX)" ${ENABLE_RELEASE}=1 ${LTO} dmd/generated/build dmd
+		env VERBOSE=1 ${HOST_DMD}="${DMD}" CXX="$(tc-getCXX)" ${ENABLE_RELEASE}=1 ${LTO} dmd/generated/build DFLAGS="$(dlang_dmdw_dcflags)" dmd
 	else
 		einfo "Building dmd..."
 		emake -C dmd/src -f posix.mak TARGET_CPU=X86 ${HOST_DMD}="${DMD}" ${HOST_CXX}="$(tc-getCXX)" ${ENABLE_RELEASE}=1 ${LTO}

--- a/profiles/use.desc
+++ b/profiles/use.desc
@@ -36,6 +36,7 @@ dmd-2_097 - Build for DMD 2.097
 dmd-2_098 - Build for DMD 2.098
 dmd-2_099 - Build for DMD 2.099
 gdc-11_2_1 - Build for GCC 11.2.1
+gdc-11_3_0 - Build for GCC 11.3.0
 ldc2-1_25 - Build for ldc2 1.25
 ldc2-1_26 - Build for ldc2 1.26
 ldc2-1_27 - Build for ldc2 1.27


### PR DESCRIPTION
Revived #100 since It got canceled while I was force pushing.

The differences are that:
1. The creation of `dmd/generated` was moved to `src_prepare`
2. There is now a helper function *dmd wrapper D compiler flags* `dlang_dmdw_dcflags` to handle the gdc `-shared-libphobos` flag
3. Correctly assigned the `KEYWORDS` variable