### PR TITLE
eclass/dlang.eclass: Change gdc slot calculation.

### DIFF
--- a/dev-util/gdmd/gdmd-11.ebuild
+++ b/dev-util/gdmd/gdmd-11.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,8 +8,8 @@ HOMEPAGE="https://www.gdcproject.org/"
 LICENSE="GPL-3+"
 
 SLOT="${PV}"
-KEYWORDS="~alpha amd64 arm arm64 ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 x86"
-RDEPEND="=sys-devel/gcc-${PV}*[d]"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+RDEPEND="sys-devel/gcc:${PV}[d]"
 RELEASE="0.1.0"
 SRC_URI="https://codeload.github.com/D-Programming-GDC/gdmd/tar.gz/script-${RELEASE} -> gdmd-${RELEASE}.tar.gz"
 PATCHES="${FILESDIR}/${PN}-no-dmd-conf.patch"

--- a/dev-util/gdmd/gdmd-12.ebuild
+++ b/dev-util/gdmd/gdmd-12.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -8,8 +8,8 @@ HOMEPAGE="https://www.gdcproject.org/"
 LICENSE="GPL-3+"
 
 SLOT="${PV}"
-KEYWORDS=" amd64 arm arm64 ~ia64 ~m68k ~mips ppc ~ppc64 ~riscv ~s390 x86"
-RDEPEND="=sys-devel/gcc-${PV}*[d]"
+KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+RDEPEND="sys-devel/gcc:${PV}[d]"
 RELEASE="0.1.0"
 SRC_URI="https://codeload.github.com/D-Programming-GDC/gdmd/tar.gz/script-${RELEASE} -> gdmd-${RELEASE}.tar.gz"
 PATCHES="${FILESDIR}/${PN}-no-dmd-conf.patch"

--- a/eclass/dlang-compilers.eclass
+++ b/eclass/dlang-compilers.eclass
@@ -54,8 +54,11 @@ dlang-compilers_declare_versions() {
 
 	# GDC (hppa, sparc: masked "d" USE-flag)
 	__dlang_gdc_frontend=(
-		["11.2.1"]="2.076 amd64 arm arm64 ~ia64 ~m68k ~mips ppc ~ppc64 ~riscv ~s390 x86"
-		["11.3.0"]="2.076 ~alpha amd64 arm arm64 ~ia64 ~m68k ~mips ppc ppc64 ~riscv ~s390 x86"
+		["11.3.1_p20221209"]="2.076 ~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+		["11.3.1_p20230120"]="2.076 ~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+		["11.3.1_p20230303"]="2.076 ~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+		["12.2.1_p20230121"]="2.100 ~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 sparc ~x86"
+		["12.2.1_p20230304"]="2.100 ~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
 	)
 
 	# LDC

--- a/profiles/use.desc
+++ b/profiles/use.desc
@@ -34,7 +34,10 @@ dmd-2_096 - Build for DMD 2.096
 dmd-2_097 - Build for DMD 2.097
 dmd-2_098 - Build for DMD 2.098
 dmd-2_099 - Build for DMD 2.099
-gdc-11_2_1 - Build for GCC 11.2.1
-gdc-11_3_0 - Build for GCC 11.3.0
+gdc-11_3_1_p20221209 - Build for GCC 11.3.1_p20221209
+gdc-11_3_1_p20230120 - Build for GCC 11.3.1_p20230120
+gdc-11_3_1_p20230303 - Build for GGG 11.3.1_p20230303
+gdc-12_2_1_p20230121 - Build for GGG 12.2.1_p20230121
+gdc-12_2_1_p20230304 - Build for GGG 12.2.1_p20230304
 ldc2-1_29 - Build for ldc2 1.29
 ldc2-1_30 - Build for ldc2 1.30


### PR DESCRIPTION
With recent changes to toolchain.eclass, gcc's (and by extension gdc's) install directory has been changed (https://gitweb.gentoo.org/repo/gentoo.git/tree/eclass/toolchain.eclass#n172). Now, instead of the 3 version component, the directory path is only formed from the major version. 

This would mean that gdmd dependency becomes any gcc in a certain slot. dlang.eclass is updated to reflect that, in addition, any package build with gdc will depend on both it and gdmd. The gdmd dependency should be build time only, which is not the case currently.

This approach has only 1 problem, that of a stable gdmd depending on an unstable gcc.
If the user had an unstable gcc installed and then either installed gdmd or a package with USE=gdc-*, gdmd would be dependant on that unstable version of gcc, which goes against Gentoo policy.
This, however, becomes a problem only when stabilising gdmd, so, in its current state of being unstable on all arches, as well as all gdc targets being unstable, will be fine.

However, I am uncertain on how this policy should be interpreted, does it say that a stable package must have a way to satisfy its dependencies with only stable packages, or does it say that a stable package may not have a way to satisfy its dependencies with any unstable package. This question is important because it dictates how gdmd's keywords are to be stabilised based on gcc's.

Another approach would be to have a seperate gdmd version for each compiler release, having the same keywords so no discrepancy could happen. Yet, this would involve a lot of gdmd versions, as well as frequent stabilisations and bumps. This can be achieved with automation, but, for now, to get any solution in place, the gdmd-slot.ebuild approach makes the most sense.

