### PR TITLE
dmd.eclass: specify compiler path when selfhosting

### DIFF
--- a/eclass/dmd.eclass
+++ b/eclass/dmd.eclass
@@ -178,7 +178,7 @@ dmd_src_compile() {
 	fi
 	if dmd_ge 2.094; then
 		einfo "Building dmd build script..."
-		dlang_compile_bin dmd/generated/build dmd/src/build.d
+		DC="${DMD}" dlang_compile_bin dmd/generated/build dmd/src/build.d
 		einfo "Building dmd..."
 		env VERBOSE=1 ${HOST_DMD}="${DMD}" CXX="$(tc-getCXX)" ${ENABLE_RELEASE}=1 ${LTO} dmd/generated/build DFLAGS="$(dlang_dmdw_dcflags)" dmd
 	else


### PR DESCRIPTION
`dlang_compile_bin` uses the `DC` variable to compile the source files. Since we're selfhosting we have to tell it the path of the compiler otherwise it will be left with a useless value, in this case `dmd`, hiding the bug when the dmd package was installed on the system.

I am not sure if the path should be relative or absolute, `$DMD` currently is: `linux/bin64/dmd`. Perhaps `DC=${S}/${DMD}` would be better.