### PR TITLE
dmd.eclass: Properly assign DC when not selfhosting

### DIFF
--- a/eclass/dmd.eclass
+++ b/eclass/dmd.eclass
@@ -159,7 +159,7 @@ dmd_src_compile() {
 	dmd_ge 2.081 && ENABLE_RELEASE="ENABLE_RELEASE" || ENABLE_RELEASE="RELEASE"
 
 	# Special case for self-hosting (i.e. no compiler USE flag selected).
-	local kernel model
+	local kernel model actual_compiler
 	if [ "${DC_VERSION}" == "selfhost" ]; then
 		case "${KERNEL}" in
 			"linux")   kernel="linux";;
@@ -175,10 +175,14 @@ dmd_src_compile() {
 		if ! dmd_ge 2.094; then
 			export DMD="../../${DMD}"
 		fi
+		actual_compiler="${S}/${DMD}"
+	else
+		# Not selfhosting, leave the compiler variable unchanged
+		actual_compiler="${DC}"
 	fi
 	if dmd_ge 2.094; then
 		einfo "Building dmd build script..."
-		DC="${DMD}" dlang_compile_bin dmd/generated/build dmd/src/build.d
+		DC="${actual_compiler}" dlang_compile_bin dmd/generated/build dmd/src/build.d
 		einfo "Building dmd..."
 		env VERBOSE=1 ${HOST_DMD}="${DMD}" CXX="$(tc-getCXX)" ${ENABLE_RELEASE}=1 ${LTO} dmd/generated/build DFLAGS="$(dlang_dmdw_dcflags)" dmd
 	else


### PR DESCRIPTION
In 2adabe7 I added `DC="${DMD}"` to the `dlang_compile_bin` function. This only happens to be valid when the compiler is dmd. This is because `dlang_compile_bin` will pass arguments to the compiler thinking that said compiler is the actual compiler and not a wrapper script.

When compiling with `ldc`, so long as the user hasn't specified any `LDCFLAGS`, the build will work fine. For `gdc` however, the eclass always adds `-shared-libphobos` to `GDCFLAGS` which is a value `gdmd` doesn't understand and which will lead to a failure. When I tested the commit I only tested it for `dmd` and `ldc` (for which I had no flags in `make.conf`) and it seemed to work fine. Least to say I will try to do less such assumptions in the future.