### PR TITLE
Various fixes

### DIFF
--- a/dev-lang/ldc2/ldc2-1.29.0-r2.ebuild
+++ b/dev-lang/ldc2/ldc2-1.29.0-r2.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -12,13 +12,13 @@ S=${WORKDIR}/${MY_P}
 
 DESCRIPTION="LLVM D Compiler"
 HOMEPAGE="https://github.com/ldc-developers/ldc"
-KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
+KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
 LICENSE="BSD"
 SLOT="$(ver_cut 1-2)/$(ver_cut 3)"
 
 IUSE="static-libs"
 
-# We support LLVM 9.0 through 14.
+# We support LLVM 6.0 through 14.
 RDEPEND="dev-util/ninja
 	|| (
 		sys-devel/llvm:13
@@ -33,15 +33,10 @@ PATCHES="${FILESDIR}/ldc2-1.15.0-link-defaultlib-shared.patch"
 # For now, we support amd64 multilib. Anyone is free to add more support here.
 MULTILIB_COMPAT=( abi_x86_{32,64} )
 
-# Upstream supports "2.079-"
-DLANG_VERSION_RANGE="2.075-2.080 2.082-"
+DLANG_VERSION_RANGE="2.075-"
 DLANG_PACKAGE_TYPE="single"
 
 inherit dlang
-
-detect_hardened() {
-	gcc --version | grep -o Hardened
-}
 
 src_prepare() {
 	cmake_src_prepare
@@ -58,7 +53,6 @@ d_src_configure() {
 	)
 	use static-libs && mycmakeargs+=( -DBUILD_SHARED_LIBS=BOTH ) || mycmakeargs+=( -DBUILD_SHARED_LIBS=ON )
 	use abi_x86_32 && use abi_x86_64 && mycmakeargs+=( -DMULTILIB=ON )
-	detect_hardened && mycmakeargs+=( -DADDITIONAL_DEFAULT_LDC_SWITCHES=' "-relocation-model=pic",' )
 	cmake_src_configure
 }
 

--- a/dev-lang/ldc2/ldc2-1.29.0-r2.ebuild
+++ b/dev-lang/ldc2/ldc2-1.29.0-r2.ebuild
@@ -48,7 +48,7 @@ d_src_configure() {
 	local mycmakeargs=(
 		-DD_VERSION=2
 		-DCMAKE_INSTALL_PREFIX=/usr/lib/ldc2/$(ver_cut 1-2)
-		-DD_COMPILER="${DMD}"
+		-DD_COMPILER="${DMD} $(dlang_dmdw_dcflags)"
 		-DLDC_WITH_LLD=OFF
 	)
 	use static-libs && mycmakeargs+=( -DBUILD_SHARED_LIBS=BOTH ) || mycmakeargs+=( -DBUILD_SHARED_LIBS=ON )

--- a/dev-lang/ldc2/ldc2-1.30.0-r1.ebuild
+++ b/dev-lang/ldc2/ldc2-1.30.0-r1.ebuild
@@ -49,7 +49,7 @@ d_src_configure() {
 	local mycmakeargs=(
 		-DD_VERSION=2
 		-DCMAKE_INSTALL_PREFIX=/usr/lib/ldc2/$(ver_cut 1-2)
-		-DD_COMPILER="${DMD}"
+		-DD_COMPILER="${DMD} $(dlang_dmdw_dcflags)"
 		-DLDC_WITH_LLD=OFF
 	)
 	use static-libs && mycmakeargs+=( -DBUILD_SHARED_LIBS=BOTH ) || mycmakeargs+=( -DBUILD_SHARED_LIBS=ON )

--- a/dev-lang/ldc2/ldc2-1.30.0-r1.ebuild
+++ b/dev-lang/ldc2/ldc2-1.30.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2022 Gentoo Authors
+# Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -12,13 +12,13 @@ S=${WORKDIR}/${MY_P}
 
 DESCRIPTION="LLVM D Compiler"
 HOMEPAGE="https://github.com/ldc-developers/ldc"
-KEYWORDS="amd64 ~arm ~arm64 ~ppc64 x86"
+KEYWORDS="~amd64 ~arm ~arm64 ~ppc64 ~x86"
 LICENSE="BSD"
 SLOT="$(ver_cut 1-2)/$(ver_cut 3)"
 
 IUSE="static-libs"
 
-# We support LLVM 6.0 through 14.
+# We support LLVM 9.0 through 14.
 RDEPEND="dev-util/ninja
 	|| (
 		sys-devel/llvm:13
@@ -33,14 +33,11 @@ PATCHES="${FILESDIR}/ldc2-1.15.0-link-defaultlib-shared.patch"
 # For now, we support amd64 multilib. Anyone is free to add more support here.
 MULTILIB_COMPAT=( abi_x86_{32,64} )
 
-DLANG_VERSION_RANGE="2.075-"
+# Upstream supports "2.079-"
+DLANG_VERSION_RANGE="2.075-2.080 2.082-"
 DLANG_PACKAGE_TYPE="single"
 
 inherit dlang
-
-detect_hardened() {
-	gcc --version | grep -o Hardened
-}
 
 src_prepare() {
 	cmake_src_prepare
@@ -57,7 +54,6 @@ d_src_configure() {
 	)
 	use static-libs && mycmakeargs+=( -DBUILD_SHARED_LIBS=BOTH ) || mycmakeargs+=( -DBUILD_SHARED_LIBS=ON )
 	use abi_x86_32 && use abi_x86_64 && mycmakeargs+=( -DMULTILIB=ON )
-	detect_hardened && mycmakeargs+=( -DADDITIONAL_DEFAULT_LDC_SWITCHES=' "-relocation-model=pic",' )
 	cmake_src_configure
 }
 

--- a/dev-util/dlang-tools/dlang-tools-2.064.2.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.064.2.ebuild
@@ -28,7 +28,7 @@ DEPEND="dman? ( =dev-lang/dmd-${PV}*:${DLANG_SLOT} )"
 DLANG_VERSION_RANGE="${DLANG_SLOT}"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}"
 
@@ -63,4 +63,12 @@ d_src_install() {
 			dobin "tools/generated/linux/default/${tool}"
 		fi
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.065.0.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.065.0.ebuild
@@ -28,7 +28,7 @@ DEPEND="dman? ( =dev-lang/dmd-${PV}*:${DLANG_SLOT} )"
 DLANG_VERSION_RANGE="${DLANG_SLOT}-2.071"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}"
 
@@ -65,4 +65,12 @@ d_src_install() {
 			dobin "tools/generated/${CHOST}/${tool}"
 		fi
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.066.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.066.1.ebuild
@@ -28,7 +28,7 @@ DEPEND="dman? ( =dev-lang/dmd-${PV}*:${DLANG_SLOT} )"
 DLANG_VERSION_RANGE="${DLANG_SLOT}"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}"
 
@@ -65,4 +65,12 @@ d_src_install() {
 			dobin "tools/generated/${CHOST}/${tool}"
 		fi
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.067.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.067.1.ebuild
@@ -31,7 +31,7 @@ PATCHES=( "${FILESDIR}/2.067-no-narrowing.patch" "${FILESDIR}/replace-bits-mathd
 DLANG_VERSION_RANGE="${DLANG_SLOT}-2.070"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}"
 
@@ -76,4 +76,12 @@ d_src_install() {
 			dobin tools/generated/linux/*/"${tool}"
 		fi
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.068.2.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.068.2.ebuild
@@ -23,7 +23,7 @@ SRC_URI="${GITHUB_URI}/tools/tar.gz/v${PV} -> dlang-tools-${PV}.tar.gz"
 DLANG_VERSION_RANGE="${DLANG_SLOT}-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}"
 
@@ -41,4 +41,12 @@ d_src_install() {
 			dobin tools-"${PV}"/generated/linux/*/"${tool}"
 		fi
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.069.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.069.1.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="${GITHUB_URI}/v${VERSION}.tar.gz -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.069.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.069.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="${GITHUB_URI}/v${VERSION}.tar.gz -> dlang-tools-${VERSION}.tar.gz"
 DLANG_VERSION_RANGE="${DLANG_SLOT}-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -48,4 +48,12 @@ d_src_install() {
 			dobin generated/linux/*/"${tool}"
 		fi
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.070.2.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.070.2.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="${DLANG_SLOT}-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -48,4 +48,12 @@ d_src_install() {
 			dobin generated/linux/*/"${tool}"
 		fi
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.070.2.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.070.2.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.071.2.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.071.2.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="${DLANG_SLOT}-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -53,4 +53,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.071.2.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.071.2.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.072.2.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.072.2.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="${DLANG_SLOT}-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -53,4 +53,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.072.2.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.072.2.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.073.2.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.073.2.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="${DLANG_SLOT}-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -53,4 +53,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.073.2.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.073.2.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.074.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.074.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="${DLANG_SLOT}-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -53,4 +53,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.074.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.074.1.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.075.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.075.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="${DLANG_SLOT}-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -53,4 +53,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.075.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.075.1.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.076.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.076.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="${DLANG_SLOT}-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.076.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.076.1.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.077.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.077.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="${DLANG_SLOT}-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.077.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.077.1.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.078.3.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.078.3.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="${DLANG_SLOT}-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.078.3.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.078.3.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.079.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.079.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="${DLANG_SLOT}-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.079.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.079.1.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.080.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.080.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="2.075-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.080.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.080.1.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.081.2.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.081.2.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="2.075-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.081.2.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.081.2.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.082.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.082.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="2.075-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.082.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.082.1.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.083.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.083.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="2.075-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.083.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.083.1.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.084.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.084.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="2.075-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.084.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.084.1.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.085.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.085.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="2.075-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.085.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.085.1.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.086.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.086.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="2.075-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.086.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.086.1.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.087.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.087.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="2.075-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.087.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.087.1.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.088.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.088.1.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.088.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.088.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="2.076-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.089.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.089.1.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.089.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.089.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="2.076-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.090.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.090.1.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.090.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.090.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="2.076-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.091.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.091.1.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.091.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.091.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="2.076-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.092.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.092.1.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.092.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.092.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="2.076-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.093.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.093.1.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.093.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.093.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="2.076-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.094.2.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.094.2.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.094.2.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.094.2.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="2.076-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.095.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.095.1.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.095.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.095.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="2.076-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.096.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.096.1.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.096.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.096.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="2.076-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.097.2.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.097.2.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="2.075-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.097.2.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.097.2.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.098.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.098.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="2.075-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/dev-util/dlang-tools/dlang-tools-2.098.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.098.1.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.099.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.099.1.ebuild
@@ -22,7 +22,8 @@ BETA="$(ver_cut 4)"
 VERSION="$(ver_cut 1-3)"
 
 if [[ -n "${BETA}" ]]; then
-	VERSION="${VERSION}-b${BETA:4}"
+	# We want to convert a Gentoo version string into an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	VERSION="$(ver_rs 3 "-" 4 ".")"
 fi
 SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-tools-${VERSION}.tar.gz"
 

--- a/dev-util/dlang-tools/dlang-tools-2.099.1.ebuild
+++ b/dev-util/dlang-tools/dlang-tools-2.099.1.ebuild
@@ -30,7 +30,7 @@ SRC_URI="https://codeload.github.com/dlang/tools/tar.gz/v${VERSION} -> dlang-too
 DLANG_VERSION_RANGE="2.076-"
 DLANG_PACKAGE_TYPE="single"
 
-inherit eutils dlang
+inherit eutils dlang xdg-utils
 
 S="${WORKDIR}/tools-${VERSION}"
 
@@ -52,4 +52,12 @@ d_src_install() {
 	for size in 16 22 24 32 48 256; do
 		newicon --size "${size}" --context mimetypes "${FILESDIR}/icons/${size}/dmd-source.png" text-x-dsrc.png
 	done
+}
+
+pkg_postinst() {
+	xdg_icon_cache_update
+}
+
+pkg_postrm() {
+	xdg_icon_cache_update
 }

--- a/eclass/dmd.eclass
+++ b/eclass/dmd.eclass
@@ -194,11 +194,18 @@ dmd_src_compile() {
 	fi
 
 	compile_libraries() {
+		local mymakeargs=(
+			DMD="../$(dmd_gen_exe_dir)/dmd"
+			MODEL="${MODEL}"
+			PIC=1
+			CC="$(tc-getCC)"
+		)
+
 		einfo 'Building druntime...'
-		emake -C druntime -f posix.mak DMD="../$(dmd_gen_exe_dir)/dmd" MODEL=${MODEL} PIC=1 MANIFEST=
+		emake -C druntime -f posix.mak "${mymakeargs[@]}" MANIFEST=
 
 		einfo 'Building Phobos 2...'
-		emake -C phobos -f posix.mak DMD="../$(dmd_gen_exe_dir)/dmd" MODEL=${MODEL} PIC=1 CUSTOM_DRUNTIME=1
+		emake -C phobos -f posix.mak "${mymakeargs[@]}" CUSTOM_DRUNTIME=1
 	}
 
 	dmd_foreach_abi compile_libraries

--- a/eclass/dmd.eclass
+++ b/eclass/dmd.eclass
@@ -181,7 +181,7 @@ dmd_src_compile() {
 		einfo "Building dmd build script..."
 		DC="${DMD}" dlang_compile_bin dmd/generated/build dmd/src/build.d
 		einfo "Building dmd..."
-		env VERBOSE=1 ${HOST_DMD}="${DMD}" CXX="$(tc-getCXX)" ${ENABLE_RELEASE}=1 ${LTO} dmd/generated/build DFLAGS="$(dlang_dmdw_dcflags)" dmd
+		env VERBOSE=1 ${HOST_DMD}="${DMD}" CXX="$(tc-getCXX)" ${ENABLE_RELEASE}=1 ${LTO} dmd/generated/build DFLAGS="$(dlang_dmdw_dcflags)" dmd || die
 	else
 		einfo "Building dmd..."
 		emake -C dmd/src -f posix.mak TARGET_CPU=X86 ${HOST_DMD}="${DMD}" ${HOST_CXX}="$(tc-getCXX)" ${ENABLE_RELEASE}=1 ${LTO}

--- a/eclass/dmd.eclass
+++ b/eclass/dmd.eclass
@@ -92,7 +92,8 @@ fi
 EXPORT_FUNCTIONS src_prepare src_compile src_test src_install pkg_postinst pkg_postrm
 
 if [[ -n "${BETA}" ]]; then
-	SRC_URI="http://downloads.dlang.org/pre-releases/${MAJOR}.x/${VERSION}/${PN}.${VERSION}-b${BETA:4}.${ARCHIVE}"
+	# We want to convert a Gentoo version string to an upstream one: 2.097.0_rc1 -> 2.097.0-rc.1
+	SRC_URI="http://downloads.dlang.org/pre-releases/${MAJOR}.x/${VERSION}/${PN}.$(ver_rs 3 "-" 4 ".").${ARCHIVE}"
 else
 	SRC_URI="mirror://aws/${YEAR}/${PN}.${PV}.${ARCHIVE}"
 fi


### PR DESCRIPTION
A bunch of small features and improvements, no major fixes.

744442c6d16962c09d24a336ef2bd92087f35735 is a little more interesting than the others. Since ldc2 uses the CommandLine llvm utility, passing multiple arguments for the same option causes an error (even if all those arguments have the same value). So, by embedding `-relocation-model=pic` into the executable it will be impossible to pass the `-relocation-model` flag at runtime lest an error occurs. This is actually what happens in dmd, and because the failure wasn't caught by the ebuild, it would continue to try to build phobos and druntime where is shold have failed. Instead, the build script fell back to using `/usr/bin/dmd`, without outputting any messages that it did or that it was compiling anything and it happened to work. I only noticed the bug because of the weird line:
```
ldc2: for the --relocation-model option: may only occur zero or one times!
```
which I assumed was a warning because I couldn't see any error but the truncated long hinted at a bigger problem. A proper check has been added in 52fbe825e5cd9252ce80e3297aebc9805ec5f57d making sure that the build script finished succesfully. ldc2 defaults  to pic on linux anyway so nothing is lost if we don't add the flag ourselves.
