### PR TITLE
dlang.eclass: improve environment variables

### DIFF
--- a/eclass/dlang.eclass
+++ b/eclass/dlang.eclass
@@ -584,7 +584,7 @@ _dlang_build_configurations() {
 						variants="${variants} ${abi}-${version_component}"
 					done
 				else
-					variants="default-${version_component}"
+					variants="${DEFAULT_ABI:-default}-${version_component}"
 				fi
 				;;
 			selfhost)
@@ -647,10 +647,15 @@ _dlang_use_build_vars() {
 		# gcc's SLOT is its major version component.
 		export DC="/usr/${CHOST_default}/gcc-bin/${DC_VERSION}/${CHOST_default}-gdc"
 		export DMD="/usr/${CHOST_default}/gcc-bin/${DC_VERSION}/gdmd"
-		if [[ "${DLANG_PACKAGE_TYPE}" == "multi" ]] && multilib_is_native_abi; then
+		if [[ ${DLANG_PACKAGE_TYPE} != multi ]]; then
+			# Both single and dmd enter this branch
 			export LIBDIR_${ABI}="lib/gcc/${CHOST_default}/${DC_VERSION}"
 		else
-			export LIBDIR_${ABI}="lib/gcc/${CHOST_default}/${DC_VERSION}/${MODEL}"
+			if multilib_is_native_abi; then
+				export LIBDIR_${ABI}="lib/gcc/${CHOST_default}/${DC_VERSION}"
+			else
+				export LIBDIR_${ABI}="lib/gcc/${CHOST_default}/${DC_VERSION}/${MODEL}"
+			fi
 		fi
 		export DCFLAGS="${GDCFLAGS} -shared-libphobos"
 		export DLANG_LINKER_FLAG="-Xlinker "

--- a/eclass/dmd.eclass
+++ b/eclass/dmd.eclass
@@ -295,8 +295,26 @@ EOF
 		fi
 
 		# Install shared lib.
+		# dlang.eclass will set LIBDIR_$ABI to the path of the host compiler
+		# library direcory (if not selfhosting). We don't care about that
+		# location, however, and we instead want to have it point
+		# to the path where this package is supposed to install the libraries
+		# to, i.e. the system library directory. We can use $LIBDIR_HOST
+		# to restore that value to the correct one but only if the ABI
+		# this function is running into is the same as the one set
+		# by dlang.eclass. Since dlang.eclass treats dmd as a 'single'
+		# type package, it will only treat the case where $ABI is the
+		# native one.
+		if ! use selfhost && multilib_is_native_abi; then
+			# We aren't going to use LIBDIR_$ABI for this ABI anymore
+			# so just overwrite it, don't bother saving it.
+			export LIBDIR_${ABI}="${LIBDIR_HOST}"
+		fi
+
+		# We are installing the real file into the system libdir.
 		dolib.so phobos/generated/linux/release/${MODEL}/"${SONAME}"
 		dosym "${SONAME}" /usr/"$(get_libdir)"/"${SONAME_SYM}"
+		# We create an additional symlink in this package's specific libdir.
 		dosym ../../../../../usr/"$(get_libdir)"/"${SONAME}" /usr/"${libdir}"/libphobos2.so
 
 		# Install static lib if requested.


### PR DESCRIPTION
This PR adds 2 functionalities to the eclass.

1. It allows ebuilds to query D libraries for pkg-config files (`x11-terms/tilix` requiring `dev-libs/gtkd`)
2. It allows packages to disable D compiler backends (`tilix` doesn't work with `dmd` or `gdc`, `onedrive` doesn't work with `gdc` etc.)