### PR TITLE
dev-lang/ldc2: update LLVM package name

### DIFF
--- a/dev-lang/ldc2/ldc2-1.32.2-r1.ebuild
+++ b/dev-lang/ldc2/ldc2-1.32.2-r1.ebuild
@@ -21,9 +21,9 @@ IUSE="static-libs"
 # Upstream supports LLVM 9.0 through 15.0.
 RDEPEND="
 	|| (
-		sys-devel/llvm:15
+		llvm-core/llvm:15
 	)
-	<sys-devel/llvm-16:=
+	<llvm-core/llvm-16:=
 	>=app-eselect/eselect-dlang-20140709"
 DEPEND="${RDEPEND}"
 LLVM_MAX_SLOT=15

--- a/dev-lang/ldc2/ldc2-1.33.0-r1.ebuild
+++ b/dev-lang/ldc2/ldc2-1.33.0-r1.ebuild
@@ -21,9 +21,9 @@ IUSE="static-libs"
 # Upstream supports LLVM 9.0 through 15.0.
 RDEPEND="
 	|| (
-		sys-devel/llvm:15
+		llvm-core/llvm:15
 	)
-	<sys-devel/llvm-16:=
+	<llvm-core/llvm-16:=
 	>=app-eselect/eselect-dlang-20140709"
 DEPEND="${RDEPEND}"
 LLVM_MAX_SLOT=15

--- a/dev-lang/ldc2/ldc2-1.34.0-r1.ebuild
+++ b/dev-lang/ldc2/ldc2-1.34.0-r1.ebuild
@@ -21,10 +21,10 @@ IUSE="static-libs"
 # Upstream supports LLVM 11.0 through 16.
 RDEPEND="
 	|| (
-		sys-devel/llvm:16
-		sys-devel/llvm:15
+		llvm-core/llvm:16
+		llvm-core/llvm:15
 	)
-	<sys-devel/llvm-17:=
+	<llvm-core/llvm-17:=
 	>=app-eselect/eselect-dlang-20140709"
 DEPEND="${RDEPEND}"
 LLVM_MAX_SLOT=16

--- a/dev-lang/ldc2/ldc2-1.35.0-r2.ebuild
+++ b/dev-lang/ldc2/ldc2-1.35.0-r2.ebuild
@@ -21,10 +21,10 @@ IUSE="static-libs"
 # Upstream supports LLVM 11.0 through 16.0.
 DEPEND="
 	|| (
-		sys-devel/llvm:16
-		sys-devel/llvm:15
+		llvm-core/llvm:16
+		llvm-core/llvm:15
 	)
-	<sys-devel/llvm-17:="
+	<llvm-core/llvm-17:="
 IDEPEND=">=app-eselect/eselect-dlang-20140709"
 RDEPEND="
 	${DEPEND}

--- a/dev-lang/ldc2/ldc2-1.36.0-r2.ebuild
+++ b/dev-lang/ldc2/ldc2-1.36.0-r2.ebuild
@@ -39,7 +39,7 @@ REQUIRED_USE=${DLANG_REQUIRED_USE}
 DEPEND="
 	${DLANG_DEPS}
 	$(llvm_gen_dep '
-	  sys-devel/llvm:${LLVM_SLOT}=
+	  llvm-core/llvm:${LLVM_SLOT}=
 	')
 	net-misc/curl[${MULTILIB_USEDEP}]
 "
@@ -80,7 +80,7 @@ src_prepare(){
 
 src_configure() {
 	# We disable assertions so we have to apply the same workaround as for
-	# sys-devel/llvm: add -DNDEBUG to CPPFLAGS.
+	# llvm-core/llvm: add -DNDEBUG to CPPFLAGS.
 	local CPPFLAGS="${CPPFLAGS} -DNDEBUG"
 	# https://bugs.gentoo.org/show_bug.cgi?id=922590
 	append-flags -fno-strict-aliasing

--- a/dev-lang/ldc2/ldc2-1.37.0.ebuild
+++ b/dev-lang/ldc2/ldc2-1.37.0.ebuild
@@ -38,7 +38,7 @@ REQUIRED_USE=${DLANG_REQUIRED_USE}
 DEPEND="
 	${DLANG_DEPS}
 	$(llvm_gen_dep '
-	  sys-devel/llvm:${LLVM_SLOT}=
+	  llvm-core/llvm:${LLVM_SLOT}=
 	')
 	net-misc/curl[${MULTILIB_USEDEP}]
 "

--- a/dev-lang/ldc2/ldc2-1.38.0.ebuild
+++ b/dev-lang/ldc2/ldc2-1.38.0.ebuild
@@ -44,7 +44,7 @@ REQUIRED_USE=${DLANG_REQUIRED_USE}
 DEPEND="
 	${DLANG_DEPS}
 	$(llvm_gen_dep '
-	  sys-devel/llvm:${LLVM_SLOT}=
+	  llvm-core/llvm:${LLVM_SLOT}=
 	')
 	net-misc/curl[${MULTILIB_USEDEP}]
 "

--- a/dev-lang/ldc2/ldc2-1.39.0.ebuild
+++ b/dev-lang/ldc2/ldc2-1.39.0.ebuild
@@ -44,7 +44,7 @@ REQUIRED_USE=${DLANG_REQUIRED_USE}
 DEPEND="
 	${DLANG_DEPS}
 	$(llvm_gen_dep '
-	  sys-devel/llvm:${LLVM_SLOT}=
+	  llvm-core/llvm:${LLVM_SLOT}=
 	')
 	net-misc/curl[${MULTILIB_USEDEP}]
 "


### PR DESCRIPTION
Due to the renaming of LLVM-related package categories in ::gentoo, ldc2 was broken.
This fixes that.